### PR TITLE
Extracted and exposed mocktail response creation.

### DIFF
--- a/Mocktail/MocktailResponse.h
+++ b/Mocktail/MocktailResponse.h
@@ -15,12 +15,14 @@
 
 @interface MocktailResponse : NSObject
 
-@property (nonatomic, strong) NSRegularExpression *methodRegex;
-@property (nonatomic, strong) NSRegularExpression *absoluteURLRegex;
-@property (nonatomic, strong) NSURL *fileURL;
-@property (nonatomic) NSInteger bodyOffset;
-@property (nonatomic, strong) NSDictionary *headers;
-@property (nonatomic) NSInteger statusCode;
+@property (nonatomic, strong, readonly) NSRegularExpression *methodRegex;
+@property (nonatomic, strong, readonly) NSRegularExpression *absoluteURLRegex;
+@property (nonatomic, strong, readonly) NSURL *fileURL;
+@property (nonatomic, readonly) NSInteger bodyOffset;
+@property (nonatomic, strong, readonly) NSDictionary *headers;
+@property (nonatomic, readonly) NSInteger statusCode;
 @property (nonatomic, weak) Mocktail *mocktail;
+
++ (MocktailResponse *)mocktailResponseForFileAtURL:(NSURL *)url;
 
 @end

--- a/Mocktail/MocktailResponse.h
+++ b/Mocktail/MocktailResponse.h
@@ -23,6 +23,10 @@
 @property (nonatomic, readonly) NSInteger statusCode;
 @property (nonatomic, weak) Mocktail *mocktail;
 
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithFileAtURL:(NSURL *)fileURL NS_DESIGNATED_INITIALIZER;
+
 + (MocktailResponse *)mocktailResponseForFileAtURL:(NSURL *)url;
 
 @end

--- a/Mocktail/MocktailResponse.m
+++ b/Mocktail/MocktailResponse.m
@@ -11,5 +11,54 @@
 #import "MocktailResponse.h"
 
 
+@interface MocktailResponse()
+
+@property (nonatomic, strong) NSRegularExpression *methodRegex;
+@property (nonatomic, strong) NSRegularExpression *absoluteURLRegex;
+@property (nonatomic, strong) NSURL *fileURL;
+@property (nonatomic) NSInteger bodyOffset;
+@property (nonatomic, strong) NSDictionary *headers;
+@property (nonatomic) NSInteger statusCode;
+
+@end
+
+
 @implementation MocktailResponse
+
++ (MocktailResponse *)mocktailResponseForFileAtURL:(NSURL *)url {
+    NSAssert(url, @"Expected valid URL.");
+
+    NSError *error;
+    NSStringEncoding originalEncoding;
+    NSString *contentsOfFile = [NSString stringWithContentsOfURL:url usedEncoding:&originalEncoding error:&error];
+    if (error) {
+        NSLog(@"Error opening %@: %@", url, error);
+        return nil;
+    }
+
+    NSScanner *scanner = [NSScanner scannerWithString:contentsOfFile];
+    NSString *headerMatter = nil;
+    [scanner scanUpToString:@"\n\n" intoString:&headerMatter];
+    NSArray *lines = [headerMatter componentsSeparatedByString:@"\n"];
+    if ([lines count] < 4) {
+        NSLog(@"Invalid amount of lines: %u", (unsigned)[lines count]);
+        return nil;
+    }
+
+    MocktailResponse *response = [MocktailResponse new];
+    response.methodRegex = [NSRegularExpression regularExpressionWithPattern:lines[0] options:NSRegularExpressionCaseInsensitive error:nil];
+    response.absoluteURLRegex = [NSRegularExpression regularExpressionWithPattern:lines[1] options:NSRegularExpressionCaseInsensitive error:nil];
+    response.statusCode = [lines[2] integerValue];
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    for (NSString *line in [lines subarrayWithRange:NSMakeRange(3, lines.count - 3)]) {
+        NSArray* parts = [line componentsSeparatedByString:@":"];
+        [headers setObject:[[parts lastObject] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]
+                    forKey:[parts firstObject]];
+    }
+    response.headers = headers;
+    response.fileURL = url;
+    response.bodyOffset = [headerMatter dataUsingEncoding:originalEncoding].length + 2;
+    return response;
+}
+
 @end

--- a/Mocktail/MocktailResponse.m
+++ b/Mocktail/MocktailResponse.m
@@ -25,40 +25,46 @@
 
 @implementation MocktailResponse
 
+- (instancetype)initWithFileAtURL:(NSURL *)url {
+    self = [super init];
+    if (self) {
+        NSError *error;
+        NSStringEncoding originalEncoding;
+        NSString *contentsOfFile = [NSString stringWithContentsOfURL:url usedEncoding:&originalEncoding error:&error];
+        if (error) {
+            NSLog(@"Error opening %@: %@", url, error);
+            return nil;
+        }
+
+        NSScanner *scanner = [NSScanner scannerWithString:contentsOfFile];
+        NSString *headerMatter = nil;
+        [scanner scanUpToString:@"\n\n" intoString:&headerMatter];
+        NSArray *lines = [headerMatter componentsSeparatedByString:@"\n"];
+        if ([lines count] < 4) {
+            NSLog(@"Invalid amount of lines: %u", (unsigned)[lines count]);
+            return nil;
+        }
+
+        _methodRegex = [NSRegularExpression regularExpressionWithPattern:lines[0] options:NSRegularExpressionCaseInsensitive error:nil];
+        _absoluteURLRegex = [NSRegularExpression regularExpressionWithPattern:lines[1] options:NSRegularExpressionCaseInsensitive error:nil];
+        _statusCode = [lines[2] integerValue];
+        NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+        for (NSString *line in [lines subarrayWithRange:NSMakeRange(3, lines.count - 3)]) {
+            NSArray* parts = [line componentsSeparatedByString:@":"];
+            headers[[parts firstObject]] = [[parts lastObject] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        }
+        _headers = headers;
+        _fileURL = url;
+        _bodyOffset = [headerMatter dataUsingEncoding:originalEncoding].length + 2;
+    }
+
+    return self;
+}
+
 + (MocktailResponse *)mocktailResponseForFileAtURL:(NSURL *)url {
     NSAssert(url, @"Expected valid URL.");
 
-    NSError *error;
-    NSStringEncoding originalEncoding;
-    NSString *contentsOfFile = [NSString stringWithContentsOfURL:url usedEncoding:&originalEncoding error:&error];
-    if (error) {
-        NSLog(@"Error opening %@: %@", url, error);
-        return nil;
-    }
-
-    NSScanner *scanner = [NSScanner scannerWithString:contentsOfFile];
-    NSString *headerMatter = nil;
-    [scanner scanUpToString:@"\n\n" intoString:&headerMatter];
-    NSArray *lines = [headerMatter componentsSeparatedByString:@"\n"];
-    if ([lines count] < 4) {
-        NSLog(@"Invalid amount of lines: %u", (unsigned)[lines count]);
-        return nil;
-    }
-
-    MocktailResponse *response = [MocktailResponse new];
-    response.methodRegex = [NSRegularExpression regularExpressionWithPattern:lines[0] options:NSRegularExpressionCaseInsensitive error:nil];
-    response.absoluteURLRegex = [NSRegularExpression regularExpressionWithPattern:lines[1] options:NSRegularExpressionCaseInsensitive error:nil];
-    response.statusCode = [lines[2] integerValue];
-    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
-    for (NSString *line in [lines subarrayWithRange:NSMakeRange(3, lines.count - 3)]) {
-        NSArray* parts = [line componentsSeparatedByString:@":"];
-        [headers setObject:[[parts lastObject] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]
-                    forKey:[parts firstObject]];
-    }
-    response.headers = headers;
-    response.fileURL = url;
-    response.bodyOffset = [headerMatter dataUsingEncoding:originalEncoding].length + 2;
-    return response;
+    return [[MocktailResponse alloc] initWithFileAtURL:url];
 }
 
 @end


### PR DESCRIPTION
Hey @AdamCampbell, you inspired me to do this.  I have extracted the code so it is still used in the original project, and basically just moves the creation from the Mocktail class to the MocktailResponse class

I noticed another guy tried to this before but it was never merged.  If the same happens here, I say we just blow away the rest of the mocktail stubbing and rename the repo, leaving only the file parsing functionality.